### PR TITLE
Fix file permission error source

### DIFF
--- a/run-ansible-playbook.sh
+++ b/run-ansible-playbook.sh
@@ -56,9 +56,10 @@ install_roles_from_ansible_galaxy(){
 provision() {
     step "preparing playbook..."
 
-    cd /vagrant/provisioning
+    mkdir -p /tmp/provisioning
+    cp -R /vagrant/provisioning/* /tmp/provisioning/
+    cd /tmp/provisioning
     chmod -x inventory
-
 
     if [[ -f vaultpassword ]]; then
         chmod -x vaultpassword


### PR DESCRIPTION
Apparently windows doesn't allow the r and x flag to be removed from files in the shared folder (namely /vagrant/provisioning/vaultpassword and /vagrant/provisioning/inventory). As workaround we move the provisioning directory to /tmp/ and provision from there.